### PR TITLE
FallFlyingLib Breaks Elytra Hopping

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,5 +26,8 @@
     },
     "custom": {
         "modmenu:api": true
+    },
+    "breaks": {
+        "elytra_bounce": "*"
     }
 }


### PR DESCRIPTION
Added the metadata in `fabric.mod.json`, so people won't wonder why is the Mixin error there. They will see a "clear" console error letting them know that this mod breaks Elytra Hopping.